### PR TITLE
Add RPG ammo placement mode to FGD.

### DIFF
--- a/fgdsrc/halflife-unified.fgd
+++ b/fgdsrc/halflife-unified.fgd
@@ -817,7 +817,14 @@
 @PointClass base(Weapon, Targetx, RenderFields) studio("models/w_argrenade.mdl") = ammo_ARgrenades : "Assault Grenades" []
 @PointClass base(Weapon, Targetx, RenderFields) studio("models/w_shotbox.mdl") = ammo_buckshot : "Shotgun Ammo" []
 @PointClass base(Weapon, Targetx, RenderFields) studio("models/w_357ammobox.mdl") = ammo_357 : "357 Ammo" []
-@PointClass base(Weapon, Targetx, RenderFields) studio("models/w_rpgammo.mdl") = ammo_rpgclip : "RPG Ammo" []
+@PointClass base(Weapon, Targetx, RenderFields) studio("models/w_rpgammo.mdl") = ammo_rpgclip : "RPG Ammo" 
+[
+  sequence(choices) : "Placement" : 0 =
+  [
+    0 : "Normal (flat)"
+    1 : "Capped"
+  ]
+]
 @PointClass base(Weapon, Targetx, RenderFields) studio("models/w_gaussammo.mdl") = ammo_gaussclip : "Gauss Gun Ammo" []
 @PointClass base(Weapon, Targetx, RenderFields) studio("models/w_crossbow_clip.mdl") = ammo_crossbow : "Crossbow Ammo" []
 


### PR DESCRIPTION
Same as #1 but with RPG ammo clip.

All LD and HD variants include these sequences. Note Opposing Force does not have a separate LD model, and instead imports the one from the base game.

The HD variants' capped sequence is the same as idle (uncapped), but a custom HD model will be available and will work as in LD.