### PR TITLE
Disable LD Op4 crowbar.

### DIFF
--- a/modelsrc/models/v_crowbar/package.bat
+++ b/modelsrc/models/v_crowbar/package.bat
@@ -18,6 +18,6 @@ rem if exist %basename%_hev_ld.mdl xcopy /F /Y %basename%_hev_ld.mdl %~dp0..\..\
 rem Copy soldier LD/HD models
 
 if exist %basename%_soldier_hd.mdl xcopy /F /Y %basename%_soldier_hd.mdl %~dp0..\..\mdl\hd\op4\%basename%.mdl*
-if exist %basename%_soldier_ld.mdl xcopy /F /Y %basename%_soldier_ld.mdl %~dp0..\..\mdl\ld\op4\%basename%.mdl*
+rem if exist %basename%_soldier_ld.mdl xcopy /F /Y %basename%_soldier_ld.mdl %~dp0..\..\mdl\ld\op4\%basename%.mdl*
 
 endlocal


### PR DESCRIPTION
The LD Op4 crowbar viewmodel still uses the LD Blue Shift animations. It should have also been reverted due to user feedback. See https://github.com/SamVanheer/halflife-unified-sdk-assets/commit/c002b906541a7371889379b30111d0f66a658c38

I rechecked the decompiled .QC files of all 3 LD variants and they all have the needed sequences, more precisely no missing sequences or swapped sequences indices. It's ok to use the original LD Op4 model.